### PR TITLE
fix(ui): update bounty task text color correctly when items are in inventory

### DIFF
--- a/src/main/java/com/nucleon/porttasks/ui/BountyTaskPanel.java
+++ b/src/main/java/com/nucleon/porttasks/ui/BountyTaskPanel.java
@@ -184,9 +184,9 @@ public BountyTaskPanel(PortTasksPlugin plugin, BountyTask bountyTask, ClientThre
 		cargoRemainingText.setForeground(Color.RED);
 	}
 
-	if (itemsLooted == lootRequirement)
+	else
 	{
-		cargoRemainingText.setText("Items: " + itemsLooted + "/" + lootRequirement);
+		cargoRemainingText.setForeground(Color.GREEN);
 	}
 
 	PortTaskInformationCenter.add(cargoRemainingText);
@@ -312,9 +312,9 @@ public BountyTaskPanel(PortTasksPlugin plugin, BountyTask bountyTask, ClientThre
 			cargoRemainingText.setForeground(Color.RED);
 		}
 
-		if (itemsLooted == lootRequirement)
+		else
 		{
-			cargoRemainingText.setText("Items: " + itemsLooted + "/" + lootRequirement);
+			cargoRemainingText.setForeground(Color.GREEN);
 		}
 		revalidate();
 		repaint();


### PR DESCRIPTION
Fixes #80.

Currently, when working on a bounty task, the side bar does not update and show correct visual completion when items are in your inventory.
The UI panel was missing the `else` logic condition to handle completion color (`Color.GREEN`) rendering, causing it to bug out the text component update.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora